### PR TITLE
feat: Allow user to set not yet existing StorageAccount name

### DIFF
--- a/AzureStorageContainer/task.json
+++ b/AzureStorageContainer/task.json
@@ -32,7 +32,10 @@
       "label": "Storage Name",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Name of the storage where to create container"
+      "helpMarkDown": "Name of the storage where to create container",
+      "properties": {
+        "EditableOptions": "True"
+      }
     },
     {
       "name": "ContainerName",


### PR DESCRIPTION
Allow free text into picklist to define StorageAccount name to an unexisting (yet at Release design time) StorageAccount.